### PR TITLE
docs: Improve README with single-line install command

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,11 +57,10 @@ sudo dnf install google-noto-sans-cjk-vf-fonts google-noto-serif-cjk-vf-fonts go
 
 `wget` を使って、設定ファイルのみをダウンロードする簡単な方法です。
 
-1.  設定ディレクトリを作成し、ファイルをダウンロードします:
+1.  以下のコマンドをコピーしてターミナルに貼り付け、実行します:
 
     ```bash
-    mkdir -p ~/.config/fontconfig/conf.d
-    wget -O ~/.config/fontconfig/conf.d/50-user-jp-fonts.conf https://raw.githubusercontent.com/nogunix/linux-japanese-font-fix/main/50-user-jp-fonts.conf
+    mkdir -p ~/.config/fontconfig/conf.d && wget -O ~/.config/fontconfig/conf.d/50-user-jp-fonts.conf https://raw.githubusercontent.com/nogunix/linux-japanese-font-fix/main/50-user-jp-fonts.conf
     ```
 
 2.  フォントキャッシュを再構築します:

--- a/README.md
+++ b/README.md
@@ -56,11 +56,10 @@ sudo dnf install google-noto-sans-cjk-vf-fonts google-noto-serif-cjk-vf-fonts go
 
 The easiest way is to download just the configuration file using `wget`.
 
-1.  Create the directory and download the configuration file:
+1.  Copy and paste the following command into your terminal and run it:
 
     ```bash
-    mkdir -p ~/.config/fontconfig/conf.d
-    wget -O ~/.config/fontconfig/conf.d/50-user-jp-fonts.conf https://raw.githubusercontent.com/nogunix/linux-japanese-font-fix/main/50-user-jp-fonts.conf
+    mkdir -p ~/.config/fontconfig/conf.d && wget -O ~/.config/fontconfig/conf.d/50-user-jp-fonts.conf https://raw.githubusercontent.com/nogunix/linux-japanese-font-fix/main/50-user-jp-fonts.conf
     ```
 
 2.  Rebuild the font cache:


### PR DESCRIPTION
Combine mkdir and wget with && to allow users to copy and paste the command in one go. This further simplifies the installation process.