### PR TITLE
Move GitHub badges to front of README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
-# Linux Japanese Font Fix
-
 [![GitHub last commit](https://img.shields.io/github/last-commit/nogunix/linux-japanese-font-fix)](https://github.com/nogunix/linux-japanese-font-fix/commits/main) [![GitHub license](https://img.shields.io/github/license/nogunix/linux-japanese-font-fix)](#license)
+
+# Linux Japanese Font Fix
 
 [English](README.md) | 日本語
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Linux Japanese Font Fix
-
 [![GitHub last commit](https://img.shields.io/github/last-commit/nogunix/linux-japanese-font-fix)](https://github.com/nogunix/linux-japanese-font-fix/commits/main) [![GitHub license](https://img.shields.io/github/license/nogunix/linux-japanese-font-fix)](#license)
+
+# Linux Japanese Font Fix
 
 English | [日本語](README.ja.md)
 


### PR DESCRIPTION
## Summary
- Move GitHub badges to the top of README.md and README.ja.md for better visibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e0efdd444832795d48107d6c67185